### PR TITLE
[CCS-38] Move temp NOTAM classes into final package structure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # key storage for secrets
 api-keys.sh
+.idea/
 
 # Created by https://www.toptal.com/developers/gitignore/api/windows,linux,macos,vim,emacs,visualstudio,visualstudiocode,python,java,venv,eclipse
 # Edit at https://www.toptal.com/developers/gitignore?templates=windows,linux,macos,vim,emacs,visualstudio,visualstudiocode,python,java,venv,eclipse

--- a/src/main/java/ou/capstone/notams/ConnectToAPI.java
+++ b/src/main/java/ou/capstone/notams/ConnectToAPI.java
@@ -1,4 +1,4 @@
-package tempNotams;
+package ou.capstone.notams;
 
 import java.net.URI;
 import java.net.URLEncoder;
@@ -8,7 +8,7 @@ import java.net.http.HttpResponse;
 import java.net.http.HttpResponse.BodyHandlers;
 import java.nio.charset.StandardCharsets;
 
-public final class ConnectToAPITemp {
+public final class ConnectToAPI {
 
     public static void main(String[] args) throws Exception {
         final String clientId = System.getenv("FAA_CLIENT_ID");

--- a/src/main/java/ou/capstone/notams/UserAirportInput.java
+++ b/src/main/java/ou/capstone/notams/UserAirportInput.java
@@ -1,11 +1,11 @@
-package tempNotams;
+package ou.capstone.notams;
 
 import java.io.Console;
 import java.util.List;
 
-public final class UserAirportInputTemp {
+public final class UserAirportInput {
 
-    private UserAirportInputTemp() { }
+    private UserAirportInput() { }
 
     /**
      * Collects exactly two airport codes from args or user prompt.


### PR DESCRIPTION
- Moved ConnectToAPITemp and UserAirportInputTemp into src/main/java/ou/capstone/notams
- Renamed files to drop Temp suffix and updated package declarations
- Removed tempNotams directory and leftover .class artifacts
- Added IDE configuration folder to .gitignore